### PR TITLE
Update lateral report layout

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -34,17 +34,24 @@
         width: 100px;
         height: 100px;
         margin: 10px;
-        text-align: center;
-        display: inline-block;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 6px;
         box-shadow: none !important;
         border: 1px solid #ccc;
         page-break-inside: avoid;
     }
-    
+
+    .result-image {
+        max-width: 40px;
+        height: auto;
+    }
+
     .result-box .percentage {
         font-size: 24px;
         font-weight: bold;
-        margin-top: 30px;
+        margin: 0;
     }
     
     /* Estilos para colores de rendimiento */

--- a/css/styles.css
+++ b/css/styles.css
@@ -450,6 +450,12 @@ textarea {
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: 6px;
+}
+
+.result-image {
+    max-width: 40px;
+    height: auto;
 }
 
 /* Diferentes estilos según el resultado */

--- a/js/app.js
+++ b/js/app.js
@@ -641,7 +641,7 @@ function generateReport() {
         }
         
         // Función para crear visualización de secuencia con imagen del personaje
-        function generateSequenceVisual(sequence) {
+        function generateSequenceVisual(sequence, imagePath = null) {
             if (!hasValidSequenceData(sequence)) return '';
             
             // Contar aciertos y fallos
@@ -672,9 +672,11 @@ function generateReport() {
             }
             
             // Crear representación visual con cuadrado y porcentaje en el centro
+            const imageHTML = imagePath ? `<img src="${imagePath}" class="result-image" alt="">` : '';
             let visual = `
             <div class="sequence-visual-container">
                 <div class="result-box ${resultClass}">
+                    ${imageHTML}
                     <div class="percentage-display">${hitPercentage}%</div>
                 </div>
                 <div class="result-stats">
@@ -726,10 +728,9 @@ function generateReport() {
                             <div class="performance-item lateral-item">
                                 <div class="lateral-header">
                                     <h4>Lateral Izquierdo (LAI)</h4>
-                                    <img src="img/cortex-person.jpg" alt="Persona Cortex" class="cortex-card-image">
                                 </div>
                                 <div class="sequence-result">
-                                    ${generateSequenceVisual(lai)}
+                                    ${generateSequenceVisual(lai, 'img/cortex-person.jpg')}
                                 </div>
                                 <p>Aciertos: ${laiStats.hits} / Fallos: ${laiStats.misses}</p>
                                 <p>Precisión: ${laiStats.accuracy}%</p>
@@ -752,10 +753,9 @@ function generateReport() {
                             <div class="performance-item lateral-item">
                                 <div class="lateral-header">
                                     <h4>Lateral Derecho (LAD)</h4>
-                                    <img src="img/cortex-person.jpg" alt="Persona Cortex" class="cortex-card-image">
                                 </div>
                                 <div class="sequence-result">
-                                    ${generateSequenceVisual(lad)}
+                                    ${generateSequenceVisual(lad, 'img/cortex-person.jpg')}
                                 </div>
                                 <p>Aciertos: ${ladStats.hits} / Fallos: ${ladStats.misses}</p>
                                 <p>Precisión: ${ladStats.accuracy}%</p>


### PR DESCRIPTION
## Summary
- show optional image in `generateSequenceVisual`
- display LAI and LAD images inside the result box
- style `result-box` to support inline images
- adjust print styles

## Testing
- `node -e "require('./js/app.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6839f811b8c48323b6a71482050801b1